### PR TITLE
Filter out our own code from the stack trace

### DIFF
--- a/lib/a/nti_manner_kick_course.rb
+++ b/lib/a/nti_manner_kick_course.rb
@@ -69,7 +69,7 @@ module A
 
       # TODO: We need to make this list more comprehensive.
       def filtering
-        %r{<internal:|/bundled_gems.rb|/(activesupport|actionpack|activerecord|bootsnap|bundler|zeitwerk)-[0-9a-z\.]+/}
+        %r{<internal:|/bundled_gems.rb|/(a-nti_manner_kick_course|activesupport|actionpack|activerecord|bootsnap|bundler|zeitwerk)-[0-9a-z\.]+/}
       end
 
       def already_checked?


### PR DESCRIPTION
Fix the issue where the following message was displayed

```
SystemExit:
  During Rails startup, the block inside ActiveSupport.on_load(active_record) was executed.
  There is code that is not being deferred as expected. The suspicious part is here.

  /Users/willnet/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/a-nti_manner_kick_course-0.1.0/lib/a/nti_manner_kick_course.rb:31:in 'block in A::NtiMannerKickCourse.monitor'

  If you want to check the entire stack trace, set the ANTI_MANNER_DEBUG environment variable.
```