### PR TITLE
Fix an issue where suggestions for suspicious lines were not working correctly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,9 +35,13 @@ jobs:
         with:
           ruby-version: 3.3.6
           bundler-cache: true
-
-      - name: Run tests
+      - name: Run Unit tests
         env:
           RAILS_ENV: test
-        run: bin/test
+        run: bin/unit-test
+
+      - name: Run E2E tests
+        env:
+          RAILS_ENV: test
+        run: bin/e2e-test
 

--- a/bin/e2e-test
+++ b/bin/e2e-test
@@ -1,5 +1,7 @@
 #!/usr/bin/env ruby
 $: << File.expand_path("../test", __dir__)
 
+ENV["DEFAULT_TEST"] = "test/e2e/*_test.rb"
+
 require "bundler/setup"
 require "rails/plugin/test"

--- a/bin/unit-test
+++ b/bin/unit-test
@@ -1,0 +1,7 @@
+#!/usr/bin/env ruby
+$: << File.expand_path("../test", __dir__)
+
+ENV["DEFAULT_TEST"] = "test/unit/*_test.rb"
+
+require "bundler/setup"
+require "rails/plugin/test"

--- a/lib/a/nti_manner_kick_course.rb
+++ b/lib/a/nti_manner_kick_course.rb
@@ -69,7 +69,7 @@ module A
 
       # TODO: We need to make this list more comprehensive.
       def filtering
-        %r{<internal:|/bundled_gems.rb|/(a-nti_manner_kick_course|activesupport|actionpack|activerecord|bootsnap|bundler|zeitwerk)-[0-9a-z\.]+/}
+        %r{<internal:|/bundled_gems.rb|/(a-nti_manner_kick_course|activesupport|actionpack|activerecord|bootsnap|bundler|zeitwerk)-([0-9\.]+|[0-9a-z]{12})/}
       end
 
       def already_checked?

--- a/test/e2e/rails_boot_test.rb
+++ b/test/e2e/rails_boot_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class A::NtiMannerKickCourseTest < ActiveSupport::TestCase
+class RailsBootTest < ActiveSupport::TestCase
   def setup
     ENV["ANTI_MANNER"] = nil
     ENV["INJECT_ANTI_MANNER"] = nil

--- a/test/unit/unit_test.rb
+++ b/test/unit/unit_test.rb
@@ -1,0 +1,10 @@
+require "test_helper"
+require "a/nti_manner_kick_course"
+class UnitTest < ActiveSupport::TestCase
+  test "filtering works correctly" do
+    assert_match A::NtiMannerKickCourse.filtering, "/Users/willnet/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/activesupport-7.1.3.4/lib/active_support/lazy_load_hooks.rb:97:in `class_eval'"
+    assert_match A::NtiMannerKickCourse.filtering, "/Users/willnet/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/bundler/gems/activesupport-b7785b412d18/lib/active_support/lazy_load_hooks.rb:97:in `class_eval'"
+    assert_no_match A::NtiMannerKickCourse.filtering, "/Users/willnet/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/activerecord-bitemporal-5.2.0/lib/activerecord-bitemporal/bitemporal.rb:299:in `block in <module:Persistence>'"
+    assert_no_match A::NtiMannerKickCourse.filtering, "/Users/willnet/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/activerecord-bitemporal-5.2.0/lib/activerecord-bitemporal.rb:5:in `<main>'"
+  end
+end


### PR DESCRIPTION
Fixed a case where backtrace filtering did not work properly for gems with names like "activerecord-bitemporal".

Previously, tests assumed that a-nti_manner_kick_course was not loaded before execution. To address this, tests were split into e2e and unit tests, running in separate processes. A new unit test was added.

Since "test/system" is excluded by default when running tests, "test/e2e" was used instead.
