### PR TITLE
Add a method for developers who are creating gems to extend Rails.

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ And then execute:
 $ bundle
 ```
 
-## Usage
+## Usage for rails application developers
 
 Start your Rails application with the ANTI_MANNER environment variable as follows.
 
@@ -124,6 +124,18 @@ If the ANTI_MANNER environment variable is not set, this gem does nothing.
 
 > [!CAUTION]
 > If you are using Spring, this gem will not work correctly. In that case, add DISABLE_SPRING=1 to your command before running it.
+
+## Usage for gem developers
+
+`A::NtiMannerKickcourse.monitor { require 'your_gem' }` allows you to run the specified code in a new process and exit with status code 1 if lazy loading is not properly deferred.
+
+Execute `require 'your_gem'` within the `A::NtiMannerKickcourse.monitor` block as follows:
+
+```ruby
+A::NtiMannerKickcourse.monitor { require 'your_gem' }
+```
+
+When this code runs, if `your_gem` interferes with lazy loading, an error message will be displayed and the process will exit with status code 1. This helps you quickly identify and fix lazy loading issues.
 
 ## License
 The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).

--- a/lib/a/nti_manner_kick_course/railtie.rb
+++ b/lib/a/nti_manner_kick_course/railtie.rb
@@ -5,10 +5,7 @@ module A
     class Railtie < ::Rails::Railtie
       initializer "anti_manner", before: :eager_load! do
         if A::NtiMannerKickCourse.enabled?
-          A::NtiMannerKickCourse.finish_monitoring
-
-          puts "✅Congratulations! No code was found that fails to defer execution!"
-          exit
+          A::NtiMannerKickCourse.wrapup!
         end
       end
     end

--- a/test/e2e/anti_manner_gem.rb
+++ b/test/e2e/anti_manner_gem.rb
@@ -1,0 +1,5 @@
+require "active_record"
+
+module AntiMannerGem
+  ActiveRecord::Base
+end

--- a/test/e2e/gem_test.rb
+++ b/test/e2e/gem_test.rb
@@ -1,0 +1,26 @@
+require "test_helper"
+
+class GemTest < ActiveSupport::TestCase
+  def setup
+    ENV["ANTI_MANNER_DEBUG"] = nil
+  end
+
+  test "A::NtiMannerKickCourse.monitor_gem exits with status code 1 when improper code is detected and anti manner is enabled" do
+    pid = fork { require "a/nti_manner_kick_course"; A::NtiMannerKickCourse.monitor_gem {  require_relative "anti_manner_gem" } }
+    status = Process::Status.wait(pid)
+    assert_equal 1, status.exitstatus
+  end
+
+  test "A::NtiMannerKickCourse.monitor_gem exits with status code 0 when proper code is detected and anti_manner is enabled" do
+    pid = fork {  require "a/nti_manner_kick_course"; A::NtiMannerKickCourse.monitor_gem { require "a/nti_manner_kick_course"; require_relative "good_manner_gem" } }
+    status = Process::Status.wait(pid)
+    assert_equal 0, status.exitstatus
+  end
+
+  test "A::NtiMannerKickCourse.monitor_gem exits with status code 1 when improper code is detected, anti manner is enabled, and debug is on" do
+    ENV["ANTI_MANNER_DEBUG"] = "1"
+    pid = fork { require "a/nti_manner_kick_course"; A::NtiMannerKickCourse.monitor_gem {  require_relative "anti_manner_gem" } }
+    status = Process::Status.wait(pid)
+    assert_equal 1, status.exitstatus
+  end
+end

--- a/test/e2e/good_manner_gem.rb
+++ b/test/e2e/good_manner_gem.rb
@@ -1,0 +1,2 @@
+module GoodMannerGem
+end


### PR DESCRIPTION
I created a method to help developers avoid accidentally loading Rails components without lazy loading when they build gems for extending Rails.

```ruby
A::NtiMannerKickCourse.monitor { require 'your_gem' }
```

By running this regularly in CI, you can make sure your gem is lazy loading Rails components properly.
