### PR TITLE
Reduce the dependencies required

### DIFF
--- a/a-nti_manner_kick_course.gemspec
+++ b/a-nti_manner_kick_course.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |spec|
     Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
   end
 
-  spec.add_dependency "rails", ">= 7.0.0"
+  spec.add_dependency "activesupport", ">= 7.0.0"
 end

--- a/a-nti_manner_kick_course.gemspec
+++ b/a-nti_manner_kick_course.gemspec
@@ -18,5 +18,6 @@ Gem::Specification.new do |spec|
     Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
   end
 
+  spec.add_dependency "railties", ">= 7.0.0"
   spec.add_dependency "activesupport", ">= 7.0.0"
 end


### PR DESCRIPTION
Hello!

I saw your gem linked from [this article ](https://blog.arkency.com/i-do-not-blindly-trust-setting-things-in-new-framework-defaults-initializers-anymore/?utm_source=shortruby&ref=shortruby.com) and I'd like to use it in our project.  We don't require all of rails so I'd like to reduce the number of dependencies required by this gem. 

My best understanding of your code is that it only requires the ActiveSupport gem because of the reference to `ActiveSupport.on_load` on line `lib/a/nti_manner_kick_course.rb:101`

When we added it, it pulled in all the rails dependencies that we aren't using:
```
diff --git a/Gemfile.lock b/Gemfile.lock
index 38d5ae1ea..14abe263b 100644
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -187,6 +187,34 @@ GEM
   remote: https://rubygems.org/
   specs:
     Ascii85 (2.0.1)
+    a-nti_manner_kick_course (0.2.1)
+      rails (>= 7.0.0)
+    actioncable (7.1.5.1)
+      actionpack (= 7.1.5.1)
+      activesupport (= 7.1.5.1)
+      nio4r (~> 2.0)
+      websocket-driver (>= 0.6.1)
+      zeitwerk (~> 2.6)
+    actionmailbox (7.1.5.1)
+      actionpack (= 7.1.5.1)
+      activejob (= 7.1.5.1)
+      activerecord (= 7.1.5.1)
+      activestorage (= 7.1.5.1)
+      activesupport (= 7.1.5.1)
+      mail (>= 2.7.1)
+      net-imap
+      net-pop
+      net-smtp
+    actionmailer (7.1.5.1)
+      actionpack (= 7.1.5.1)
+      actionview (= 7.1.5.1)
+      activejob (= 7.1.5.1)
+      activesupport (= 7.1.5.1)
+      mail (~> 2.5, >= 2.5.4)
+      net-imap
+      net-pop
+      net-smtp
+      rails-dom-testing (~> 2.2)
     actionpack (7.1.5.1)
       actionview (= 7.1.5.1)
       activesupport (= 7.1.5.1)
```

Let me know what you think!